### PR TITLE
Add explicit Delete methods for tensors, graphs, and status

### DIFF
--- a/tensorflow/go/attrs.go
+++ b/tensorflow/go/attrs.go
@@ -40,6 +40,8 @@ func (op *Operation) Attr(name string) (interface{}, error) {
 	defer C.free(unsafe.Pointer(cname))
 
 	status := newStatus()
+	defer status.Delete()
+
 	meta := C.TF_OperationGetAttrMetadata(op.c, cname, status.c)
 	if err := status.Err(); err != nil {
 		return nil, err
@@ -53,6 +55,7 @@ func (op *Operation) Attr(name string) (interface{}, error) {
 
 func listAttribute(op *Operation, cname *C.char, meta C.TF_AttrMetadata) (interface{}, error) {
 	status := newStatus()
+	defer status.Delete()
 
 	switch meta._type {
 	case C.TF_ATTR_STRING:
@@ -182,6 +185,7 @@ func listAttribute(op *Operation, cname *C.char, meta C.TF_AttrMetadata) (interf
 
 func scalarAttribute(op *Operation, cname *C.char, meta C.TF_AttrMetadata) (interface{}, error) {
 	status := newStatus()
+	defer status.Delete()
 
 	switch meta._type {
 	case C.TF_ATTR_STRING:

--- a/tensorflow/go/operation.go
+++ b/tensorflow/go/operation.go
@@ -62,6 +62,7 @@ func (op *Operation) OutputListSize(output string) (int, error) {
 	cname := C.CString(output)
 	defer C.free(unsafe.Pointer(cname))
 	status := newStatus()
+	defer status.Delete()
 	n := C.TF_OperationOutputListLength(op.c, cname, status.c)
 	return int(n), status.Err()
 }
@@ -96,6 +97,8 @@ func (p Output) DataType() DataType {
 // Shape returns the (possibly incomplete) shape of the tensor produced p.
 func (p Output) Shape() Shape {
 	status := newStatus()
+	defer status.Delete()
+
 	port := p.c()
 	ndims := C.TF_GraphGetTensorNumDims(p.Op.g.c, port, status.c)
 	if err := status.Err(); err != nil {

--- a/tensorflow/go/saved_model.go
+++ b/tensorflow/go/saved_model.go
@@ -47,6 +47,8 @@ type SavedModel struct {
 // https://www.tensorflow.org/code/tensorflow/python/saved_model/
 func LoadSavedModel(exportDir string, tags []string, options *SessionOptions) (*SavedModel, error) {
 	status := newStatus()
+	defer status.Delete()
+
 	cOpt, doneOpt, err := options.c()
 	defer doneOpt()
 	if err != nil {

--- a/tensorflow/go/status.go
+++ b/tensorflow/go/status.go
@@ -42,7 +42,6 @@ func newStatus() *status {
 func (s *status) finalizer() {
 	s.m.Lock()
 	defer s.m.Unlock()
-
 	if s.c != nil {
 		C.TF_DeleteStatus(s.c)
 	}

--- a/tensorflow/go/status.go
+++ b/tensorflow/go/status.go
@@ -19,37 +19,63 @@ package tensorflow
 // #include "tensorflow/c/c_api.h"
 import "C"
 
-import "runtime"
+import (
+	"runtime"
+	"sync"
+)
 
 type code C.TF_Code
 
 // status holds error information returned by TensorFlow. We convert all
 // TF statuses to Go errors.
 type status struct {
+	m sync.Mutex
 	c *C.TF_Status
 }
 
 func newStatus() *status {
-	s := &status{C.TF_NewStatus()}
+	s := &status{c: C.TF_NewStatus()}
 	runtime.SetFinalizer(s, (*status).finalizer)
 	return s
 }
 
 func (s *status) finalizer() {
-	C.TF_DeleteStatus(s.c)
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	if s.c != nil {
+		C.TF_DeleteStatus(s.c)
+	}
+	s.c = nil
+}
+
+func (s *status) Delete() {
+	s.finalizer()
 }
 
 func (s *status) Code() code {
+	s.m.Lock()
+	defer s.m.Unlock()
+	return code(C.TF_GetCode(s.c))
+}
+
+// codeLocked returns the code without locking - only to be used when the caller already holds the lock
+func (s *status) codeLocked() code {
 	return code(C.TF_GetCode(s.c))
 }
 
 func (s *status) String() string {
+	s.m.Lock()
+	defer s.m.Unlock()
 	return C.GoString(C.TF_Message(s.c))
 }
 
 // Err converts the status to a Go error and returns nil if the status is OK.
 func (s *status) Err() error {
-	if s == nil || s.Code() == C.TF_OK {
+	s.m.Lock()
+	defer s.m.Unlock()
+	// Note that we call codeLocked here vs Code() because we are already holding the lock
+	if s == nil || s.codeLocked() == C.TF_OK {
 		return nil
 	}
 	return (*statusError)(s)

--- a/tensorflow/go/status.go
+++ b/tensorflow/go/status.go
@@ -55,7 +55,7 @@ func (s *status) Delete() {
 func (s *status) Code() code {
 	s.m.Lock()
 	defer s.m.Unlock()
-	return code(C.TF_GetCode(s.c))
+	return s.codeLocked()
 }
 
 // codeLocked returns the code without locking - only to be used when the caller already holds the lock


### PR DESCRIPTION
@metalogical @damiankite 

This PR adds explicit `Delete` methods for `Tensor`, `Graph` and `Status`. Some of these will be called within the `kiteco/kiteco` codebase, but some are used internally to cleanup extraneous objects (e.g `status` in particular). The `Graph` and `Tensor` objects whose ownership transfers into go's runtime will be cleaned up in `kiteco/kiteco` when `session.Run` is called (for tensors) or when we are done w/ a graph (for graphs). 